### PR TITLE
Update Maid.lua

### DIFF
--- a/Maid.lua
+++ b/Maid.lua
@@ -1,13 +1,60 @@
+-- Maid[key] = (function)            Adds a function to call at cleanup
+-- Maid[key] = (Instance)            Adds an Object to be Destroyed at cleanup
+-- Maid[key] = (RBXScriptConnection) Adds a connection to be Disconnected at cleanup
+-- Maid[key] = (Maid)                Maids can act as an event connection, allowing a Maid to have other maids to clean up.
+-- Maid[key] = nil                   Removes a named task. This cleans up the previous Maid[key]
 local Maid = {}
 
+--- Generates a new Maid object
+-- @return Maid
 function Maid.new()
 	return setmetatable({{}}, Maid)
 end
 
+--- Gives the Maid a Task to perform at cleanup, incremented by 1
+-- @param Variant Task An object to be Destroyed, a Connection to be Disconnected, or function/callable table to be called
+-- @returns the index the Task was placed at
+function Maid:GiveTask(Task)
+	local n = #self[1] + 1
+	self[1][n] = Task
+	return n
+end
+
+--- Makes the Maid clean up when the instance is destroyed
+-- @param Instance Instance The Instance the Maid will wait for to be Destroyed
+function Maid:LinkToInstance(Instance)
+	self:GiveTask(Instance.AncestryChanged:Connect(function(Object, Parent)
+		if Instance == Object and Parent == nil then
+			self:DoCleaning()
+		end
+	end))
+end
+
+--- Cleans up the Tasks assigned to the Maid
+-- This Disconnects RBXScriptConnections, Destroys Instances, and calls Functions/callable Tables
+function Maid:DoCleaning()
+	local Tasks = self[1]
+	for Name, Task in next, Tasks do
+		local Type = typeof(Task)
+		if Type == "RBXScriptConnection" then
+			Task:Disconnect()
+		elseif Type == "Instance" then
+			Task:Destroy()
+		else
+			Task()
+		end
+		Tasks[Name] = nil
+	end
+end
+Maid.Disconnect = Maid.DoCleaning
+Maid.Destroy = Maid.DoCleaning
+
+--- Internal __index metamethod
 function Maid:__index(i)
 	return Maid[i] or self[1][i]
 end
 
+--- Internal __newindex metamethod
 function Maid:__newindex(i, v)
 	local Tasks = self[1]
 	if v == nil then -- Clear previous Task
@@ -25,28 +72,5 @@ function Maid:__newindex(i, v)
 	end
 	Tasks[i] = v
 end
-
-function Maid:GiveTask(Task)
-	local n = #self[1] + 1
-	self[1][n] = Task
-	return n
-end
-
-function Maid:DoCleaning()
-	local Tasks = self[1]
-	for Name, Task in next, Tasks do
-		local Type = typeof(Task)
-		if Type == "RBXScriptConnection" then
-			Task:Disconnect()
-		elseif Type == "Instance" then
-			Task:Destroy()
-		else
-			Task()
-		end
-		Tasks[Name] = nil
-	end
-end
-Maid.Disconnect = Maid.DoCleaning
-Maid.Destroy = Maid.DoCleaning
 
 return Maid

--- a/README.md
+++ b/README.md
@@ -1,14 +1,27 @@
 # Maid
 Manages the cleaning of events and other things.
 
-##API
-	Maid.new()                        Returns a new Maid object.
+### API
+```cs
+Maid Maid.new()
+// Generates a new Maid object
 
-	Maid[key] = (function)            Adds a task to perform when cleaning up.
-	Maid[key] = (event connection)    Manages an event connection. Anything that isn't a function is assumed to be this.
-	Maid[key] = (Maid)                Maids can act as an event connection, allowing a Maid to have other maids to clean up.
-	Maid[key] = nil                   Removes a named task. If the task is an event, it is disconnected.
+number Maid:GiveTask(Task)
+// Adds a Task to the Maid table, incremented by 1
+// @returns index the Task was placed at
 
-	Maid:GiveTask(task)               Same as above, but uses an incremented number as a key.
-	Maid:DoCleaning()                 Disconnects all managed events and performs all clean-up Tasks.
-	Maid:Disconnect()                 Same as DoCleaning
+void Maid:DoCleaning()
+// Disconnects all Events, Destroys all Objects, and calls all functions stored as Tasks
+// Maid:Destroy() and Maid:Disconnect() are the same thing
+
+void Maid:Destroy()
+
+void Maid:Disconnect()
+```
+```
+Maid[key] = (function)            Adds a function to call at cleanup
+Maid[key] = (Instance)            Adds an Object to be Destroyed at cleanup
+Maid[key] = (RBXScriptConnection) Adds a connection to be Disconnected at cleanup
+Maid[key] = (Maid)                Maids can act as an event connection, allowing a Maid to have other maids to clean up.
+Maid[key] = nil                   Removes a named task. This cleans up the previous Maid[key]
+```

--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ void Maid:DoCleaning()
 // Disconnects all Events, Destroys all Objects, and calls all functions stored as Tasks
 // Maid:Destroy() and Maid:Disconnect() are the same thing
 
+void Maid:LinkToInstance(Instance)
+// Makes the Maid clean up when the instance is destroyed
+// @param Instance Instance The Instance the Maid will wait for to be Destroyed
+ 
 void Maid:Destroy()
+// Same as DoCleaning()
 
 void Maid:Disconnect()
+// Same as DoCleaning()
 ```
 ```
 Maid[key] = (function)            Adds a function to call at cleanup


### PR DESCRIPTION
- Updated format
- Allowed Maids to Accept Instances to `Destroy` upon Cleanup
- Added `Destroy` function (same as `DoCleaning`)
- Made `Tasks` `self[1]` rather than `self.Tasks` (doesn't affect usage)
- Backwards compatible
- Allow Maids to call callable tables as well as functions
- Add `LinkToInstance` function that will make the Maid run `DoCleaning` when an instance is Destroyed