### PR TITLE
Cleanup custom tables, enable LinkToInstance

### DIFF
--- a/Maid.lua
+++ b/Maid.lua
@@ -25,15 +25,74 @@ end
 
 --- Makes the Maid clean up when the instance is destroyed
 -- @param Instance Instance The Instance the Maid will wait for to be Destroyed
---[[
-function Maid:LinkToInstance(Instance)
-	self:GiveTask(Instance.AncestryChanged:Connect(function(Object, Parent)
-		if Parent == nil then
-			self:DoCleaning()
-		end
-	end))
+-- @returns Disconnectable table to stop Maid from being cleaned up upon Instance Destroy (automatically cleaned up by Maid, btw)
+-- @author Corecii
+
+local Disconnect = {Connected = true}
+Disconnect.__index = Disconnect
+function Disconnect:Disconnect()
+	self.Connected = false
+	self.Connection:Disconnect()
 end
---]]
+
+function Maid:LinkToInstance(Object)
+	local Reference = Instance.new("ObjectValue")
+	Reference.Value = Object
+	-- ObjectValues have weak-like Instance references
+	-- If the Instance can no longer be accessed then it can be collected despite
+	--  the ObjectValue having a reference to it
+	local ManualDisconnect = setmetatable({}, Disconnect)
+	local Connection
+	local function ChangedFunction(Obj, Par)
+		if not Reference.Value then
+			ManualDisconnect.Connected = false
+			return self:DoCleaning()
+		elseif Obj == Reference.Value and not Par then
+			Obj = nil
+			coroutine.yield()  -- Push further execution of this script to the end of the current execution cycle
+					  --  This is needed because when the event first runs it's always still Connected
+			-- The object may have been reparented or the event manually disconnected or disconnected and ran in that time...
+			if (not Reference.Value or not Reference.Value.Parent) and ManualDisconnect.Connected then
+				if not Connection.Connected then
+					ManualDisconnect.Connected = false
+					return self:DoCleaning()
+				else
+					-- Since this event won't fire if the instance is destroyed while in nil, we have to check
+					--  often to make sure it's not destroyed. Once it's parented outside of nil we can stop doing
+					--  this. We also must check to make sure it wasn't manually disconnected or disconnected and ran.
+					while wait(0.2) do
+						if not ManualDisconnect.Connected then
+							-- Don't run func, we were disconnected manually
+							return
+						elseif not Connection.Connected then
+							-- Otherwise, if we're disconnected it's because instance was destroyed
+							ManualDisconnect.Connected = false
+							return self:DoCleaning()
+						elseif Reference.Value.Parent then
+							-- If it's still Connected then it's not destroyed. If it has a parent then
+							--  we can quit checking if it's destroyed like this.
+							return
+						end
+					end
+				end
+			end
+		end
+	end
+	Connection = Object.AncestryChanged:Connect(ChangedFunction)
+	ManualDisconnect.Connection = Connection
+	Object = nil
+	-- If the object is currently in nil then we need to start our destroy checking loop
+	-- We need to spawn a new Roblox Lua thread right now before any other code runs.
+	--  spawn() starts it on the next cycle or frame, coroutines don't have ROBLOX's coroutine.yield handler
+	--  The only option left is BindableEvents, which run as soon as they are called and use ROBLOX's yield
+	local QuickRobloxThreadSpawner = Instance.new("BindableEvent")
+	QuickRobloxThreadSpawner.Event:Connect(ChangedFunction)
+	QuickRobloxThreadSpawner:Fire(Reference.Value, Reference.Value.Parent)
+	QuickRobloxThreadSpawner:Destroy()
+	self._Tasks[#self._Tasks + 1] = ManualDisconnect -- Give Task to Maid, cleanup this Connection upon cleanup
+	return ManualDisconnect
+end
+
 
 --- Cleans up the Tasks assigned to the Maid
 -- This Disconnects RBXScriptConnections, Destroys Instances, and calls Functions/callable Tables
@@ -41,9 +100,10 @@ function Maid:DoCleaning()
 	local Tasks = self._Tasks
 	for Name, Task in next, Tasks do
 		local Type = typeof(Task)
-		if Type == "RBXScriptConnection" then
+		local IsTable = Type == "table"
+		if Type == "RBXScriptConnection" or IsTable and Task.Disconnect then
 			Task:Disconnect()
-		elseif Type == "Instance" then
+		elseif Type == "Instance" or IsTable and Task.Destroy then
 			Task:Destroy()
 		else
 			Task()
@@ -53,7 +113,6 @@ function Maid:DoCleaning()
 end
 Maid.Disconnect = Maid.DoCleaning
 Maid.Destroy = Maid.DoCleaning
-Maid.__call = Maid.DoCleaning
 
 --- Internal __index metamethod
 function Maid:__index(i)
@@ -66,9 +125,10 @@ function Maid:__newindex(i, v)
 	local Task = Tasks[i]
 	if Task or v == nil then -- Clear previous Task
 		local Type = typeof(Task)
-		if Type == "RBXScriptConnection" then
+		local IsTable = Type == "table"
+		if Type == "RBXScriptConnection" or IsTable and Task.Disconnect then
 			Task:Disconnect()
-		elseif Type == "Instance" or getmetatable(Task) == Maid then
+		elseif Type == "Instance" or IsTable and Task.Destroy then
 			Task:Destroy()
 		end
 	end

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ number Maid:GiveTask(Task)
 // Adds a Task to the Maid table, incremented by 1
 // @returns index the Task was placed at
 
+void Maid:LinkToInstance(Instance)
+// Makes the Maid clean up when the instance is destroyed
+// @param Instance Instance The Instance the Maid will wait for to be Destroyed
+// @returns table Connection that can be Disconnect()ed to unlink to Instance
+
 void Maid:DoCleaning()
 // Disconnects all Events, Destroys all Objects, and calls all functions stored as Tasks
 // Maid:Destroy() and Maid:Disconnect() are the same thing
@@ -19,10 +24,6 @@ void Maid:Destroy()
 
 void Maid:Disconnect()
 // Same as DoCleaning()
-
-// [Planned] void Maid:LinkToInstance(Instance)
-// Makes the Maid clean up when the instance is destroyed
-// @param Instance Instance The Instance the Maid will wait for to be Destroyed
 ```
 ```
 Maid[key] = (function)            Adds a function to call at cleanup


### PR DESCRIPTION
- Makes Maid call any custom `Disconnect` or `Destroy` function within a table
- Enable LinkToInstance (Makes Maid cleanup when Instance is Destroyed)
- Removed `__call` metamethod hotfix, however any table passed to Maid without `Disconnect` or `Destroy` will be called like a function

Credit to Corecii for the [instanceDestroyed Module](https://www.roblox.com/library/483039669/instanceDestroyed-Module)